### PR TITLE
docs(claude): record pull-request field findings in the skill

### DIFF
--- a/configs/claude/skills/pull-request/SKILL.md
+++ b/configs/claude/skills/pull-request/SKILL.md
@@ -45,15 +45,26 @@ than filling the slot.
    review of the wrong thing. Use the `commit` skill for the message. Leave unrelated
    untracked files alone and say later that you did.
 
-4. **Confirm the range is not empty** before writing a word:
+4. **Confirm the range is exactly what you mean to propose** before writing a word:
 
    ```bash
-   git diff --stat "origin/$BASE...HEAD"
+   git log --oneline "origin/$BASE..HEAD"
    ```
 
-   Empty output means the branch does not actually differ from the base — usually step
-   2 gone wrong, sometimes a fetch that moved the base past you. Stop and fix it. An
-   empty PR with a beautifully written body is worse than no PR.
+   Both ways this can be wrong ship a PR that misrepresents itself, and neither
+   announces itself later:
+
+   - **Empty.** The branch does not differ from the base — usually step 2 gone wrong,
+     sometimes a fetch that moved the base past you. An empty PR with a beautifully
+     written body is worse than no PR.
+   - **More commits than you expect.** A branch cut from a local default branch that was
+     itself ahead of the remote carries those unpushed commits along, and they will land
+     in your PR as if they were part of the work. Read the list and confirm every commit
+     belongs. If one doesn't, that is the user's unpushed work and their call — ask
+     whether to push it to the base first and rebase, or to rebase it out of the branch.
+     Do not quietly include it and do not quietly drop it.
+
+   Stop and resolve either case before composing anything.
 
 Verify and push come _after_ the body is written — see "Verify, push, create". Checks
 like `nix flake check` take minutes and tell you nothing you need in order to write
@@ -359,8 +370,20 @@ Read two things from the output:
   exits 0 with `No mermaid charts found` — so the exit code alone will happily bless a
   body that forgot the mandatory diagram. Confirm N is what you expect.
 
-Then look at the PNG. Parsing and being readable are different bars, and a diagram
-GitHub has scaled into illegibility passes the first while failing the reviewer.
+Then look at the PNG. Parsing and being readable are different bars, and the failures
+that clear the first one are the dangerous kind because nothing reports them:
+
+- **A long edge routed behind a node** reads as an edge between that node and the
+  target — the diagram then asserts a relationship you never wrote. Watch for this when
+  one node fans out to several others in `LR`; switching to `TD`, or grouping the
+  targets into `subgraph`s, usually straightens the routing out.
+- **Edge labels landing next to the wrong edge** when several arrows leave the same
+  node, so the reader attaches your text to a different relationship than you meant.
+- **A diagram GitHub scales into illegibility**, which passes the parse and fails the
+  reviewer.
+
+All three are layout, not syntax, so the fix is to restructure and re-render rather
+than to reword.
 
 `mmdc` rasterizes through a headless browser, which is why Chrome is involved; handing
 it over via `PUPPETEER_EXECUTABLE_PATH` keeps this inside `nix run` instead of letting
@@ -402,6 +425,21 @@ Pass the body with `--body-file`; `--body` mangles newlines and the mermaid fenc
 `gh pr checks --watch` blocks until CI settles and exits non-zero on failure — never
 `sleep` and poll. If the repo reports no checks the command errors out; that is not a
 failure, so note it and move on.
+
+Some setups deny `git push` outright, and pushing is not something to route around — a
+denial is a decision, not an obstacle. The body is already the valuable part and it is
+already on disk, so hand it over instead of discarding the work: give the user the
+exact commands to run themselves, with the real `$BODY` path substituted in.
+
+```text
+! git push -u origin <branch>
+! gh pr create --base <base> --title "<title>" --body-file <the actual path>
+```
+
+The `!` prefix runs it in their Claude Code session, so the output lands back in the
+conversation and you can pick up at `gh pr checks --watch`. The same applies if
+`gh pr create` is denied but the push went through — hand over only the step you were
+blocked on, not the whole sequence.
 
 When checks fail, read the failing job (`gh run view <id> --log-failed`) and report
 what broke. Fix it if the cause is in this branch; ask first if the fix would widen


### PR DESCRIPTION
## Summary

- Three failure modes turned up while actually running the `pull-request` skill, and
  what they have in common is that none of them announces itself — each hangs off a
  step that otherwise reports success. The skill now names all three at the step where
  they occur.
- **The range check only guarded against an empty diff.** A branch cut from a local
  default branch that is ahead of the remote silently carries the user's unpushed
  commits into the PR, and `git diff --stat` looks perfectly healthy while it happens.
  The check is now `git log --oneline`, which makes the commit list readable and forces
  a decision on anything unexpected instead of a glance at a line count.
- **`mmdc` exiting 0 means the mermaid parses, not that it reads correctly.** An edge
  routed behind a node, or a label landing next to the wrong arrow, asserts a
  relationship that was never written — and both survive the parse. These are layout
  failures, so the guidance says to restructure (`TD`, `subgraph`) rather than reword.
- **A denied `git push` is a decision, not an obstacle to route around.** By that point
  the body is already written and on disk, so the skill now hands the user the exact
  commands with the `!` prefix instead of discarding the work.
- Risk worth naming: this is guidance only, so nothing enforces it and nothing goes red
  if it is wrong. The cost is attention budget — the file grows by 45 lines, and a skill
  long enough to skim is a skill that stops being followed.

## Diagram

The pipeline is unchanged; what is new are the three silent-failure branches (green)
hanging off steps that report success anyway.

```mermaid
flowchart TD
  range["4. confirm the range"] --> compose["compose the body"]
  compose --> render["render with mmdc"]
  render --> verify["run the verify skill"]
  verify --> push["git push"]
  push --> create["gh pr create"]

  range -.-> extra["commits you did not expect<br/>→ ask: push to base, or rebase out"]
  render -.-> layout["parses but misreads<br/>→ restructure, do not reword"]
  push -.-> denied["push denied<br/>→ hand over the ! commands"]

  classDef added stroke:#3fb950,stroke-width:3px
  class extra,layout,denied added
```

## Files changed

| File                                     | Change   | Why                                                                                                                    |
| ---------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
| `configs/claude/skills/pull-request/SKILL.md` | +45 / -7 | Pre-flight range check rewritten around `git log`; mermaid validation gains the layout failures; push gains a hand-off path |

**Total:** 1 file, +45 / -7

## Test plan

- [x] `mmdc` renders this body — `Found 1 mermaid charts in Markdown input`, exit 0, and
      the PNG is legible with the three dashed branches clearly separate.
- [x] `nix flake check` — `all checks passed!` (eval plus the `treefmt` check, so the
      markdown is formatted as the repo expects).
- [x] The file needs no wiring change: `modules/home-manager/home/file.nix:32` links the
      whole `configs/claude/skills` directory, so an edit in place is picked up.
- [x] The guidance itself is only testable in use — the next few PRs raised with this
      skill are the real check.
